### PR TITLE
Add readme and do not recompute when selecting multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Point data conversion plugin
-HDPS plugin for point data conversion
+# Point data conversion plugin ![Build Status](https://github.com/ManiVaultStudio/PointDataConversionPlugin/actions/workflows/build.yml/badge.svg?branch=master)
+
+Point data conversion plugin for the [ManiVault](https://github.com/ManiVaultStudio/core) visual analytics framework.
+
+```bash
+git clone git@github.com:ManiVaultStudio/PointDataConversionPlugin.git
+```
+
+Applies an element-wise transformation to a selected dataset in-place.
+
+Implemented transformations:
+- [Inverse hyperbolic sine](https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions) (`asinh`)
+- [Binary logarithm](https://en.wikipedia.org/wiki/Binary_logarithm) (`log2`)
+
+## How to use
+- Right-click on a point dataset and select `Transform` -> `Conversion` and chose the transformation function

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -8,7 +8,7 @@
 
 #include <QDebug>
 
-Q_PLUGIN_METADATA(IID "nl.BioVault.PointDataConversionPlugin")
+Q_PLUGIN_METADATA(IID "studio.manivault.PointDataConversionPlugin")
 
 using namespace mv;
 

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -25,55 +25,55 @@ PointDataConversionPlugin::PointDataConversionPlugin(const PluginFactory* factor
 
 void PointDataConversionPlugin::transform()
 {
-    for (auto inputDataset : getInputDatasets()) {
-        auto points = Dataset<Points>(inputDataset);
+    auto points = getInputDataset<Points>();
 
-        if (!points.isValid())
-            continue;
+    if (!points.isValid())
+        return;
 
-        QApplication::processEvents();
+    QApplication::processEvents();
         
-        auto& task = points->getTask();
+    auto& task = points->getTask();
         
-        task.setName("Converting");
-        task.setRunning();
-        task.setProgressDescription(QString("%1 conversion").arg(getTypeName(_type)));
+    task.setName("Converting");
+    task.setRunning();
+    task.setProgressDescription(QString("%1 conversion").arg(getTypeName(_type)));
+    
+    qDebug() << "PointDataConversionPlugin:: Apply " << getTypeName(_type) << " conversion to " << points->getGuiName();
+
+    points->visitData([this, &points, &task](auto pointData) {
+        std::uint32_t noPointsProcessed = 0;
         
-        points->visitData([this, &points, &task](auto pointData) {
-            std::uint32_t noPointsProcessed = 0;
+        for (auto point : pointData) {
+            for (std::int32_t dimensionIndex = 0; dimensionIndex < points->getNumDimensions(); dimensionIndex++) {
+                switch (_type)
+                {
+                    case PointDataConversionPlugin::Type::Log2:
+                        point[dimensionIndex] = std::log2(point[dimensionIndex] + 1);
+                        break;
         
-            for (auto point : pointData) {
-                for (std::int32_t dimensionIndex = 0; dimensionIndex < points->getNumDimensions(); dimensionIndex++) {
-                    switch (_type)
-                    {
-                        case PointDataConversionPlugin::Type::Log2:
-                            point[dimensionIndex] = log2(point[dimensionIndex] + 1);
-                            break;
+                    case PointDataConversionPlugin::Type::ArcSin:
+                        point[dimensionIndex] = std::asinh(point[dimensionIndex] / 5.0f);
+                        break;
         
-                        case PointDataConversionPlugin::Type::ArcSin:
-                            point[dimensionIndex] = asinh(point[dimensionIndex] / 5.0f);
-                            break;
-        
-                        default:
-                            break;
-                    }
-                }
-        
-                ++noPointsProcessed;
-        
-                if (noPointsProcessed % 1000 == 0) {
-                    task.setProgress(static_cast<float>(noPointsProcessed) / static_cast<float>(points->getNumPoints()));
-                    
-                    QApplication::processEvents();
+                    default:
+                        break;
                 }
             }
-        });
         
-        task.setProgress(1.0f);
-        task.setFinished();
+            ++noPointsProcessed;
         
-        events().notifyDatasetDataChanged(points);
-    }
+            if (noPointsProcessed % 1000 == 0) {
+                task.setProgress(static_cast<float>(noPointsProcessed) / static_cast<float>(points->getNumPoints()));
+                    
+                QApplication::processEvents();
+            }
+        }
+    });
+        
+    task.setProgress(1.0f);
+    task.setFinished();
+        
+    events().notifyDatasetDataChanged(points);
 }
 
 PointDataConversionPlugin::Type PointDataConversionPlugin::getType() const
@@ -116,10 +116,10 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
                 const auto typeName = PointDataConversionPlugin::getTypeName(type);
 
                 auto pluginTriggerAction = new PluginTriggerAction(const_cast<PointDataConversionPluginFactory*>(this), this, QString("Conversion/%1").arg(typeName), QString("Perform %1 data conversion").arg(typeName), getIcon(), [this, datasets, type](PluginTriggerAction& pluginTriggerAction) -> void {
-                    for (auto dataset : datasets) {
+                    for (const auto& dataset : datasets) {
                         auto pluginInstance = dynamic_cast<PointDataConversionPlugin*>(plugins().requestPlugin(getKind()));
 
-                        pluginInstance->setInputDatasets(datasets);
+                        pluginInstance->setInputDataset(dataset);
                         pluginInstance->setType(type);
                         pluginInstance->transform();
                     }
@@ -145,10 +145,10 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
             const auto typeName = PointDataConversionPlugin::getTypeName(type);
 
             auto pluginTriggerAction = new PluginTriggerAction(const_cast<PointDataConversionPluginFactory*>(this), this, QString("Conversion/%1").arg(typeName), QString("Perform %1 data conversion").arg(typeName), getIcon(), [this, type](PluginTriggerAction& pluginTriggerAction) -> void {
-                for (auto dataset : Datasets()) {
+                for (const auto& dataset : Datasets()) {
                     auto pluginInstance = dynamic_cast<PointDataConversionPlugin*>(plugins().requestPlugin(getKind()));
 
-                    pluginInstance->setInputDatasets(Datasets());
+                    pluginInstance->setInputDataset(dataset);
                     pluginInstance->setType(type);
                     pluginInstance->transform();
                 }

--- a/src/PointDataConversionPlugin.h
+++ b/src/PointDataConversionPlugin.h
@@ -79,7 +79,7 @@ class PointDataConversionPluginFactory : public TransformationPluginFactory
 {
     Q_INTERFACES(mv::plugin::TransformationPluginFactory mv::plugin::PluginFactory)
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID   "nl.BioVault.PointDataConversionPlugin"
+    Q_PLUGIN_METADATA(IID   "studio.manivault.PointDataConversionPlugin"
                       FILE  "PointDataConversionPlugin.json")
 
 public:


### PR DESCRIPTION
- Fix: Performing a transformation on multiple datasets at once executes the transformation multiple times on the same dataset, same as https://github.com/ManiVaultStudio/ExamplePlugins/pull/16
- Add readme