### PR TITLE
Channel-wise cofactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-
 # for matrix check https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
 jobs:
   prepare_matrix:
@@ -35,14 +31,14 @@ jobs:
     steps:
       - name: Checkout the source
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Checkout the source - pull request
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
@@ -59,7 +55,7 @@ jobs:
           python-version: "3.12"
 
       - name: Start ssh key agent
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.RULESSUPPORT_DEPLOY_KEY }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,10 @@ PROJECT(${PROJECT}
 # -----------------------------------------------------------------------------
 # CMake Options
 # -----------------------------------------------------------------------------
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /MP /Zc:__cplusplus")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
@@ -30,6 +28,8 @@ endif()
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData CONFIG QUIET)
+
+find_package(OpenMP)
 
 # -----------------------------------------------------------------------------
 # Source files
@@ -60,6 +60,10 @@ target_include_directories(${PROJECT} PRIVATE "${ManiVault_INCLUDE_DIR}")
 # -----------------------------------------------------------------------------
 target_compile_features(${PROJECT} PRIVATE cxx_std_20)
 
+set_target_properties(${PROJECT} PROPERTIES 
+    AUTOMOC ON
+)
+
 # -----------------------------------------------------------------------------
 # Target library linking
 # -----------------------------------------------------------------------------
@@ -68,6 +72,7 @@ target_link_libraries(${PROJECT} PRIVATE Qt6::WebEngineWidgets)
 
 target_link_libraries(${PROJECT} PRIVATE ManiVault::Core)
 target_link_libraries(${PROJECT} PRIVATE ManiVault::PointData)
+target_link_libraries(${PROJECT} PRIVATE OpenMP::OpenMP_CXX)
 
 # -----------------------------------------------------------------------------
 # Target installation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ find_package(OpenMP)
 set(SOURCES
     src/PointDataConversionPlugin.h
     src/PointDataConversionPlugin.cpp
+    src/SlidersAction.h
+    src/SlidersAction.cpp
 )
 
 set(AUX 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,7 @@
 from conans import ConanFile
 from conan.tools.cmake import CMakeDeps, CMake, CMakeToolchain
 from conans.tools import save, load
+from conans.tools import os_info, SystemPackageTool
 import os
 import shutil
 import pathlib

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ from rules_support import PluginBranchInfo
 
 
 class PointDataConversionPluginConan(ConanFile):
-    """Class to package the PointDataConversionPlugin  using conan
+    """Class to package the PointDataConversionPlugin using conan
 
     Packages both RELEASE and RELWITHDEBINFO.
     Uses rules_support (github.com/ManiVaultStudio/rulessupport) to derive
@@ -68,8 +68,13 @@ class PointDataConversionPluginConan(ConanFile):
         pass
 
     def system_requirements(self):
-        #  May be needed for macOS or Linux
-        pass
+        if os_info.is_macos:
+            installer = SystemPackageTool()
+            installer.install("libomp")
+            proc = subprocess.run("brew --prefix libomp",  shell=True, capture_output=True)
+            subprocess.run(f"ln {proc.stdout.decode('UTF-8').strip()}/lib/libomp.dylib /usr/local/lib/libomp.dylib", shell=True)
+        if os_info.is_linux:
+            self.run("sudo apt update && sudo apt install -y libtbb-dev")
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -100,8 +105,13 @@ class PointDataConversionPluginConan(ConanFile):
         tc.variables["ManiVault_DIR"] = manivault_dir
 
         # Set some build options
-        tc.variables["MV_UNITY_BUILD"] = "ON"
+        tc.cache_variables["MV_UNITY_BUILD"] = "ON"
         
+        if os_info.is_macos:
+            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)
+            prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+            tc.variables["OpenMP_ROOT"] = prefix_path
+            
         tc.generate()
 
     def _configure_cmake(self):

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -12,14 +12,14 @@ Q_PLUGIN_METADATA(IID "studio.manivault.PointDataConversionPlugin")
 
 using namespace mv;
 
-const QMap<PointDataConversionPlugin::Type, QString> PointDataConversionPlugin::types = QMap<Type, QString>({
-    { Type::Log2, "Log2" },
-    { Type::ArcSin, "Arcsin" }
+const QMap<PointDataConversionPlugin::Conversion, QString> PointDataConversionPlugin::CONVERSIONS = QMap<Conversion, QString>({
+    { Conversion::Log2, "Log2" },
+    { Conversion::ArcSin, "Arcsin" }
 });
 
 PointDataConversionPlugin::PointDataConversionPlugin(const PluginFactory* factory) :
     TransformationPlugin(factory),
-    _type(Type::ArcSin)
+    _conversion(Conversion::ArcSin)
 {
 }
 
@@ -36,20 +36,20 @@ void PointDataConversionPlugin::transform()
         
     task.setName("Converting");
     task.setRunning();
-    task.setProgressDescription(QString("%1 conversion").arg(getTypeName(_type)));
+    task.setProgressDescription(QString("%1 conversion").arg(getConversionName(_conversion)));
     
     points->visitData([this, &points, &task](auto pointData) {
         std::uint32_t noPointsProcessed = 0;
         
         for (auto point : pointData) {
             for (std::int32_t dimensionIndex = 0; dimensionIndex < points->getNumDimensions(); dimensionIndex++) {
-                switch (_type)
+                switch (_conversion)
                 {
-                    case Type::Log2:
+                    case Conversion::Log2:
                         point[dimensionIndex] = std::log2f(point[dimensionIndex] + 1.0f);
                         break;
         
-                    case Type::ArcSin:
+                    case Conversion::ArcSin:
                         point[dimensionIndex] = std::asinhf(point[dimensionIndex] / 5.0f);
                         break;
                 }
@@ -71,22 +71,22 @@ void PointDataConversionPlugin::transform()
     events().notifyDatasetDataChanged(points);
 }
 
-PointDataConversionPlugin::Type PointDataConversionPlugin::getType() const
+PointDataConversionPlugin::Conversion PointDataConversionPlugin::getConversion() const
 {
-    return _type;
+    return _conversion;
 }
 
-void PointDataConversionPlugin::setType(const Type& type)
+void PointDataConversionPlugin::setConversion(const Conversion& conversion)
 {
-    if (type == _type)
+    if (conversion == _conversion)
         return;
 
-    _type = type;
+    _conversion = conversion;
 }
 
-QString PointDataConversionPlugin::getTypeName(const Type& type)
+QString PointDataConversionPlugin::getConversionName(const Conversion& conversion)
 {
-    return types[type];
+    return CONVERSIONS[conversion];
 }
 
 PointDataConversionPluginFactory::PointDataConversionPluginFactory() :
@@ -99,52 +99,53 @@ PointDataConversionPlugin* PointDataConversionPluginFactory::produce()
     return new PointDataConversionPlugin(this);
 }
 
+
 PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(const mv::Datasets& datasets) const
 {
     PluginTriggerActions pluginTriggerActions;
 
     const auto numberOfDatasets = datasets.count();
 
-    if (PluginFactory::areAllDatasetsOfTheSameType(datasets, PointType)) {
-        if (numberOfDatasets >= 1 && datasets.first()->getDataType() == PointType) {
-            const auto addPluginTriggerAction = [this, &pluginTriggerActions, datasets](const PointDataConversionPlugin::Type& type) -> void {
-                const auto typeName = PointDataConversionPlugin::getTypeName(type);
+    if (datasets.count() >= 1 && PluginFactory::areAllDatasetsOfTheSameType(datasets, PointType)) {
+        const auto addPluginTriggerAction = [this, &pluginTriggerActions, datasets](const PointDataConversionPlugin::Conversion& type) -> void {
+            const auto typeName = PointDataConversionPlugin::getConversionName(type);
 
-                auto pluginTriggerAction = new PluginTriggerAction(const_cast<PointDataConversionPluginFactory*>(this), this, QString("Conversion/%1").arg(typeName), QString("Perform %1 data conversion").arg(typeName), icon(), [this, datasets, type](PluginTriggerAction& pluginTriggerAction) -> void {
-                    for (const auto& dataset : datasets) {
-                        auto pluginInstance = dynamic_cast<PointDataConversionPlugin*>(plugins().requestPlugin(getKind()));
+            auto pluginTriggerAction = new PluginTriggerAction(const_cast<PointDataConversionPluginFactory*>(this), this, QString("Conversion/%1").arg(typeName), QString("Perform %1 data conversion").arg(typeName), icon(), [this, datasets, type](PluginTriggerAction& pluginTriggerAction) -> void {
+                for (const auto& dataset : datasets) {
+                    auto pluginInstance = dynamic_cast<PointDataConversionPlugin*>(plugins().requestPlugin(getKind()));
 
-                        pluginInstance->setInputDataset(dataset);
-                        pluginInstance->setType(type);
-                        pluginInstance->transform();
-                    }
+                    pluginInstance->setInputDataset(dataset);
+                    pluginInstance->setConversion(type);
+                    pluginInstance->transform();
+                }
                 });
 
-                pluginTriggerActions << pluginTriggerAction;
+            pluginTriggerActions << pluginTriggerAction;
             };
 
-            addPluginTriggerAction(PointDataConversionPlugin::Type::Log2);
-            addPluginTriggerAction(PointDataConversionPlugin::Type::ArcSin);
-        }
+        addPluginTriggerAction(PointDataConversionPlugin::Conversion::Log2);
+        addPluginTriggerAction(PointDataConversionPlugin::Conversion::ArcSin);
     }
 
     return pluginTriggerActions;
 }
 
+
+// This is used in the image viewer
 PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(const mv::DataTypes& dataTypes) const
 {
     PluginTriggerActions pluginTriggerActions;
 
     if (dataTypes.count(PointType) == dataTypes.count()) {
-        const auto addPluginTriggerAction = [this, &pluginTriggerActions](const PointDataConversionPlugin::Type& type) -> void {
-            const auto typeName = PointDataConversionPlugin::getTypeName(type);
+        const auto addPluginTriggerAction = [this, &pluginTriggerActions](const PointDataConversionPlugin::Conversion& type) -> void {
+            const auto typeName = PointDataConversionPlugin::getConversionName(type);
 
             auto pluginTriggerAction = new PluginTriggerAction(const_cast<PointDataConversionPluginFactory*>(this), this, QString("Conversion/%1").arg(typeName), QString("Perform %1 data conversion").arg(typeName), icon(), [this, type](PluginTriggerAction& pluginTriggerAction) -> void {
                 for (const auto& dataset : pluginTriggerAction.getDatasets()) {
                     auto pluginInstance = dynamic_cast<PointDataConversionPlugin*>(plugins().requestPlugin(getKind()));
 
                     pluginInstance->setInputDataset(dataset);
-                    pluginInstance->setType(type);
+                    pluginInstance->setConversion(type);
                     pluginInstance->transform();
                 }
             });
@@ -154,14 +155,15 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
             pluginTriggerActions << pluginTriggerAction;
         };
 
-        addPluginTriggerAction(PointDataConversionPlugin::Type::Log2);
-        addPluginTriggerAction(PointDataConversionPlugin::Type::ArcSin);
+        addPluginTriggerAction(PointDataConversionPlugin::Conversion::Log2);
+        addPluginTriggerAction(PointDataConversionPlugin::Conversion::ArcSin);
     }
 
     return pluginTriggerActions;
 }
 
-WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const PointDataConversionPlugin::Type& type)
+// TODO: actually use the cofactor
+WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const PointDataConversionPlugin::Conversion& type)
 {
     const auto createGroupAction = [this](WidgetAction& widgetAction) -> GroupAction* {
         auto groupAction = new GroupAction(this, "PointDataConversionGroupAction");
@@ -176,10 +178,10 @@ WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const Poi
 
     switch (type)
     {
-        case PointDataConversionPlugin::Type::Log2:
+        case PointDataConversionPlugin::Conversion::Log2:
             return nullptr;
 
-        case PointDataConversionPlugin::Type::ArcSin:
+        case PointDataConversionPlugin::Conversion::ArcSin:
             return createGroupAction(_arcSinFactorAction);
     }
 

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -11,13 +11,14 @@
 Q_PLUGIN_METADATA(IID "studio.manivault.PointDataConversionPlugin")
 
 using namespace mv;
+using namespace mv::gui;
 
 const QMap<PointDataConversionPlugin::Conversion, QString> PointDataConversionPlugin::CONVERSIONS = QMap<Conversion, QString>({
     { Conversion::Log2, "Log2" },
     { Conversion::ArcSin, "Arcsin" }
 });
 
-PointDataConversionPlugin::PointDataConversionPlugin(const PluginFactory* factory) :
+PointDataConversionPlugin::PointDataConversionPlugin(const mv::plugin::PluginFactory* factory) :
     TransformationPlugin(factory),
     _conversion(Conversion::ArcSin)
 {
@@ -103,8 +104,6 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
 {
     PluginTriggerActions pluginTriggerActions;
 
-    const auto numberOfDatasets = datasets.count();
-
     if (datasets.count() >= 1 && PluginFactory::areAllDatasetsOfTheSameType(datasets, PointType)) {
         const auto addPluginTriggerAction = [this, &pluginTriggerActions, datasets](const PointDataConversionPlugin::Conversion& type) -> void {
             const auto typeName = PointDataConversionPlugin::getConversionName(type);
@@ -128,7 +127,6 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
 
     return pluginTriggerActions;
 }
-
 
 // This is used in the image viewer
 PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(const mv::DataTypes& dataTypes) const

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -14,6 +14,10 @@ Q_PLUGIN_METADATA(IID "studio.manivault.PointDataConversionPlugin")
 using namespace mv;
 using namespace mv::gui;
 
+// =============================================================================
+// PointDataConversionPlugin
+// =============================================================================
+
 const QMap<PointDataConversionPlugin::Conversion, QString> PointDataConversionPlugin::CONVERSIONS = QMap<Conversion, QString>({
     { Conversion::Log2, "Log2" },
     { Conversion::ArcSin, "Arcsin" }
@@ -101,9 +105,18 @@ QString PointDataConversionPlugin::getConversionName(const Conversion& conversio
     return CONVERSIONS[conversion];
 }
 
+// =============================================================================
+// PointDataConversionPluginFactory
+// =============================================================================
+
 PointDataConversionPluginFactory::PointDataConversionPluginFactory() :
-    _arcSinFactorAction(this, "Factor", 1.0f, 100.0f, 5.0f, 5.0f)
+    _arcSinFactorAction(this, "Factor", 1.0f, 100.0f, 5.0f, 2),
+    _arcSinFactorsAction(this, "Factors")
 {
+    QStringList opts = { "1", "2", "3" };
+    _arcSinFactorsAction.setOptions(opts);
+    for (const auto& opt : opts)
+        _arcSinFactorsAction.setDataForOption(opt, 5.f, 0.f, 100.f);
 }
 
 PointDataConversionPlugin* PointDataConversionPluginFactory::produce()
@@ -113,7 +126,11 @@ PointDataConversionPlugin* PointDataConversionPluginFactory::produce()
 
 std::vector<float> PointDataConversionPluginFactory::getArcSinCoFactor() const
 {
-    return { _arcSinFactorAction.getValue() };
+    if (_sameCofactor)
+        return { _arcSinFactorAction.getValue() };
+
+    return { _arcSinFactorsAction.getValues() };
+
 }
 
 // TODO: add gui to optionally set per-channel cofactor
@@ -197,7 +214,7 @@ WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const Poi
             return nullptr;
 
         case PointDataConversionPlugin::Conversion::ArcSin:
-            return createGroupAction(_arcSinFactorAction);
+            return createGroupAction(_arcSinFactorsAction);
     }
 
     return nullptr;

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -24,9 +24,7 @@ const QMap<PointDataConversionPlugin::Conversion, QString> PointDataConversionPl
 });
 
 PointDataConversionPlugin::PointDataConversionPlugin(const mv::plugin::PluginFactory* factory) :
-    TransformationPlugin(factory),
-    _conversion(Conversion::ArcSin),
-    _cofactors({5.f})
+    TransformationPlugin(factory)
 {
 }
 
@@ -52,6 +50,8 @@ void PointDataConversionPlugin::transform()
         const auto numPointsF   = static_cast<float>(points->getNumPoints());
         const auto numPointsI   = static_cast<std::int64_t>(points->getNumPoints());
         const auto numDims      = points->getNumDimensions();
+
+        qDebug() << "PointDataConversionPlugin::transform: cofactor of" << cofactor ;
 
 #pragma omp parallel for
         for (std::int64_t pointIndex = 0; pointIndex < numPointsI; pointIndex++) {
@@ -110,13 +110,23 @@ QString PointDataConversionPlugin::getConversionName(const Conversion& conversio
 // =============================================================================
 
 PointDataConversionPluginFactory::PointDataConversionPluginFactory() :
-    _arcSinFactorAction(this, "Factor", 1.0f, 100.0f, 5.0f, 2),
+    _sameFactorAction(this, "Same factor", true),
+    _arcSinFactorAction(this, "Factor",
+        SlidersAction::OptionData::DEFAULT_MIN, SlidersAction::OptionData::DEFAULT_MAX, 
+        SlidersAction::OptionData::DEFAULT_VALUE, SlidersAction::OptionData::DEFAULT_DECIMALS),
     _arcSinFactorsAction(this, "Factors")
 {
     QStringList opts = { "1", "2", "3" };
     _arcSinFactorsAction.setOptions(opts);
     for (const auto& opt : opts)
         _arcSinFactorsAction.setDataForOption(opt, 5.f, 0.f, 100.f);
+
+    connect(&_sameFactorAction, &ToggleAction::toggled, this, [&](bool toggled)
+    {
+        _arcSinFactorAction.setEnabled(_sameFactorAction.isChecked());
+        _arcSinFactorsAction.setAllSlidersEnabled(!_sameFactorAction.isChecked());
+    });
+
 }
 
 PointDataConversionPlugin* PointDataConversionPluginFactory::produce()
@@ -126,11 +136,10 @@ PointDataConversionPlugin* PointDataConversionPluginFactory::produce()
 
 std::vector<float> PointDataConversionPluginFactory::getArcSinCoFactor() const
 {
-    if (_sameCofactor)
+    if (_sameFactorAction.isChecked())
         return { _arcSinFactorAction.getValue() };
 
-    return { _arcSinFactorsAction.getValues() };
-
+    return _arcSinFactorsAction.getValues();
 }
 
 // TODO: add gui to optionally set per-channel cofactor
@@ -197,13 +206,15 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
 
 WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const PointDataConversionPlugin::Conversion& type)
 {
-    const auto createGroupAction = [this](WidgetAction& widgetAction) -> GroupAction* {
+    const auto createGroupAction = [this]() -> GroupAction* {
         auto groupAction = new GroupAction(this, "PointDataConversionGroupAction");
 
         groupAction->setText("Settings");
         groupAction->setToolTip("Data conversion settings");
         groupAction->setLabelSizingType(GroupAction::LabelSizingType::Auto);
-        groupAction->addAction(&widgetAction);
+        groupAction->addAction(&_sameFactorAction);
+        groupAction->addAction(&_arcSinFactorAction);
+        groupAction->addAction(&_arcSinFactorsAction);  // TODO: not correctly enabled on first open
 
         return groupAction;
     };
@@ -214,7 +225,7 @@ WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const Poi
             return nullptr;
 
         case PointDataConversionPlugin::Conversion::ArcSin:
-            return createGroupAction(_arcSinFactorsAction);
+            return createGroupAction();
     }
 
     return nullptr;

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -112,21 +112,15 @@ QString PointDataConversionPlugin::getConversionName(const Conversion& conversio
 PointDataConversionPluginFactory::PointDataConversionPluginFactory() :
     _sameFactorAction(this, "Same factor", true),
     _arcSinFactorAction(this, "Factor",
-        SlidersAction::OptionData::DEFAULT_MIN, SlidersAction::OptionData::DEFAULT_MAX, 
-        SlidersAction::OptionData::DEFAULT_VALUE, SlidersAction::OptionData::DEFAULT_DECIMALS),
+        SlidersAction::EntryData::DEFAULT_MIN, SlidersAction::EntryData::DEFAULT_MAX,
+        SlidersAction::EntryData::DEFAULT_VALUE, SlidersAction::EntryData::DEFAULT_DECIMALS),
     _arcSinFactorsAction(this, "Factors")
 {
-    QStringList opts = { "1", "2", "3" };
-    _arcSinFactorsAction.setOptions(opts);
-    for (const auto& opt : opts)
-        _arcSinFactorsAction.setDataForOption(opt, 5.f, 0.f, 100.f);
-
     connect(&_sameFactorAction, &ToggleAction::toggled, this, [&](bool toggled)
     {
         _arcSinFactorAction.setEnabled(_sameFactorAction.isChecked());
         _arcSinFactorsAction.setAllSlidersEnabled(!_sameFactorAction.isChecked());
     });
-
 }
 
 PointDataConversionPlugin* PointDataConversionPluginFactory::produce()
@@ -204,9 +198,14 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
     return pluginTriggerActions;
 }
 
-WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const PointDataConversionPlugin::Conversion& type)
+WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const PointDataConversionPlugin::Conversion& type, const mv::Dataset<mv::DatasetImpl>& inputDataset)
 {
-    const auto createGroupAction = [this]() -> GroupAction* {
+    const auto createGroupAction = [this, &inputDataset]() -> GroupAction* {
+
+        const std::vector<QString> dimNamesVec = mv::Dataset<Points>(inputDataset)->getDimensionNames();
+        const QStringList dimNamesList(dimNamesVec.begin(), dimNamesVec.end());
+        _arcSinFactorsAction.initialize(dimNamesList);
+
         auto groupAction = new GroupAction(this, "PointDataConversionGroupAction");
 
         groupAction->setText("Settings");

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -111,6 +111,11 @@ PointDataConversionPlugin* PointDataConversionPluginFactory::produce()
     return new PointDataConversionPlugin(this);
 }
 
+std::vector<float> PointDataConversionPluginFactory::getArcSinCoFactor() const
+{
+    return { _arcSinFactorAction.getValue() };
+}
+
 // TODO: add gui to optionally set per-channel cofactor
 PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(const mv::Datasets& datasets) const
 {
@@ -155,7 +160,7 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
 
                     pluginInstance->setInputDataset(dataset);
                     pluginInstance->setConversion(type);
-                    pluginInstance->setCofactor(std::vector<float>{ _arcSinFactorAction.getValue() });
+                    pluginInstance->setCofactor(getArcSinCoFactor());
 
                     pluginInstance->transform();
                 }

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -120,16 +120,35 @@ QString PointDataConversionPlugin::getConversionName(const Conversion& conversio
 
 PointDataConversionPluginFactory::PointDataConversionPluginFactory() :
     _sameFactorAction(this, "Same factor", true),
-    _arcSinFactorAction(this, "Factor",
-        SlidersAction::EntryData::DEFAULT_MIN, SlidersAction::EntryData::DEFAULT_MAX,
-        SlidersAction::EntryData::DEFAULT_VALUE, SlidersAction::EntryData::DEFAULT_DECIMALS),
+    _arcSinFactorAction(this, "Factor"),
     _arcSinFactorsAction(this, "Factors")
 {
+    _arcSinFactorAction.setToolTip("Apply the same cofactors to each channel.");
+    _arcSinFactorsAction.setToolTip("Apply different cofactors to each channel.");
+
+    _arcSinFactorAction.initialize(SlidersAction::EntryData::DEFAULT_MIN, SlidersAction::EntryData::DEFAULT_MAX,
+        SlidersAction::EntryData::DEFAULT_VALUE, SlidersAction::EntryData::DEFAULT_DECIMALS);
+
     connect(&_sameFactorAction, &ToggleAction::toggled, this, [&](bool toggled)
-    {
-        _arcSinFactorAction.setEnabled(_sameFactorAction.isChecked());
-        _arcSinFactorsAction.setAllSlidersEnabled(!_sameFactorAction.isChecked());
-    });
+        {
+            _arcSinFactorAction.setEnabled(_sameFactorAction.isChecked());
+            _arcSinFactorsAction.setAllSlidersEnabled(!_sameFactorAction.isChecked());
+        });
+
+    connect(&_arcSinFactorAction, &DecimalAction::valueChanged, this, [&](float value)
+        {
+            const auto sliderValues = _arcSinFactorsAction.getValues();
+            
+            const bool allEqual = !sliderValues.empty() &&
+            std::all_of(sliderValues.cbegin() + 1, sliderValues.cend(),
+                [&](const float v) { return std::abs(v - sliderValues.front()) < 0.0001f; });
+
+            if (!allEqual)
+                return;
+
+            _arcSinFactorsAction.setValueForAllEntries(value);        
+        });
+
 }
 
 PointDataConversionPlugin* PointDataConversionPluginFactory::produce()

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -39,10 +39,9 @@ void PointDataConversionPlugin::transform()
     task.setProgressDescription(QString("%1 conversion").arg(getConversionName(_conversion)));
     
     points->visitData([this, &points, &task](auto pointData) {
-        std::uint32_t noPointsProcessed = 0;
-        
+        std::uint64_t noPointsProcessed = 0;
         for (auto point : pointData) {
-            for (std::int32_t dimensionIndex = 0; dimensionIndex < points->getNumDimensions(); dimensionIndex++) {
+            for (std::uint64_t dimensionIndex = 0; dimensionIndex < points->getNumDimensions(); dimensionIndex++) {
                 switch (_conversion)
                 {
                     case Conversion::Log2:

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -214,7 +214,7 @@ WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const Poi
         groupAction->setLabelSizingType(GroupAction::LabelSizingType::Auto);
         groupAction->addAction(&_sameFactorAction);
         groupAction->addAction(&_arcSinFactorAction);
-        groupAction->addAction(&_arcSinFactorsAction);  // TODO: not correctly enabled on first open
+        groupAction->addAction(&_arcSinFactorsAction);
 
         return groupAction;
     };

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -136,7 +136,6 @@ std::vector<float> PointDataConversionPluginFactory::getArcSinCoFactor() const
     return _arcSinFactorsAction.getValues();
 }
 
-// TODO: add gui to optionally set per-channel cofactor
 PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(const mv::Datasets& datasets) const
 {
     PluginTriggerActions pluginTriggerActions;
@@ -147,11 +146,7 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
 
             auto pluginTriggerAction = new PluginTriggerAction(const_cast<PointDataConversionPluginFactory*>(this), this, QString("Conversion/%1").arg(typeName), QString("Perform %1 data conversion").arg(typeName), icon(), [this, datasets, type](PluginTriggerAction& pluginTriggerAction) -> void {
                 for (const auto& dataset : datasets) {
-                    auto pluginInstance = dynamic_cast<PointDataConversionPlugin*>(plugins().requestPlugin(getKind()));
-
-                    pluginInstance->setInputDataset(dataset);
-                    pluginInstance->setConversion(type);
-                    pluginInstance->transform();
+                    const_cast<PointDataConversionPluginFactory*>(this)->openConfigDialog(type, dataset);
                 }
                 });
 
@@ -165,7 +160,7 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
     return pluginTriggerActions;
 }
 
-// This is used in the image viewer
+// This is used in e.g. the image viewer
 PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(const mv::DataTypes& dataTypes) const
 {
     PluginTriggerActions pluginTriggerActions;
@@ -176,13 +171,7 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
 
             auto pluginTriggerAction = new PluginTriggerAction(const_cast<PointDataConversionPluginFactory*>(this), this, QString("Conversion/%1").arg(typeName), QString("Perform %1 data conversion").arg(typeName), icon(), [this, type](PluginTriggerAction& pluginTriggerAction) -> void {
                 for (const auto& dataset : pluginTriggerAction.getDatasets()) {
-                    auto pluginInstance = dynamic_cast<PointDataConversionPlugin*>(plugins().requestPlugin(getKind()));
-
-                    pluginInstance->setInputDataset(dataset);
-                    pluginInstance->setConversion(type);
-                    pluginInstance->setCofactor(getArcSinCoFactor());
-
-                    pluginInstance->transform();
+                    createPluginAndTransform(type, dataset);
                 }
             });
 
@@ -198,22 +187,19 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
     return pluginTriggerActions;
 }
 
-WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const PointDataConversionPlugin::Conversion& type, const mv::Dataset<mv::DatasetImpl>& inputDataset)
+WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const PointDataConversionPlugin::Conversion& type)
 {
-    const auto createGroupAction = [this, &inputDataset]() -> GroupAction* {
+    const auto createGroupAction = [this]() -> GroupAction* {
 
-        const std::vector<QString> dimNamesVec = mv::Dataset<Points>(inputDataset)->getDimensionNames();
-        const QStringList dimNamesList(dimNamesVec.begin(), dimNamesVec.end());
-        _arcSinFactorsAction.initialize(dimNamesList);
+        _arcSinFactorsAction.initialize({});
+        _sameFactorAction.setChecked(true);
 
         auto groupAction = new GroupAction(this, "PointDataConversionGroupAction");
 
         groupAction->setText("Settings");
         groupAction->setToolTip("Data conversion settings");
         groupAction->setLabelSizingType(GroupAction::LabelSizingType::Auto);
-        groupAction->addAction(&_sameFactorAction);
         groupAction->addAction(&_arcSinFactorAction);
-        groupAction->addAction(&_arcSinFactorsAction);
 
         return groupAction;
     };
@@ -228,4 +214,69 @@ WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const Poi
     }
 
     return nullptr;
+}
+
+
+void PointDataConversionPluginFactory::openConfigDialog(const PointDataConversionPlugin::Conversion& type, const mv::Dataset<mv::DatasetImpl>& inputDataset)
+{
+    _sameFactorAction.setChecked(true);
+    const std::vector<QString> dimNamesVec = mv::Dataset<Points>(inputDataset)->getDimensionNames();
+    const QStringList dimNamesList(dimNamesVec.begin(), dimNamesVec.end());
+    _arcSinFactorsAction.initialize(dimNamesList);
+
+    switch (type)
+    {
+    case PointDataConversionPlugin::Conversion::Log2:
+        createPluginAndTransform(type, inputDataset);
+        break;
+
+    case PointDataConversionPlugin::Conversion::ArcSin:
+    {
+        ConversionDialog inputDialog(nullptr, &_sameFactorAction, &_arcSinFactorAction, &_arcSinFactorsAction);
+        inputDialog.setModal(true);
+        if (inputDialog.exec() == QDialog::Accepted)
+            createPluginAndTransform(type, inputDataset);
+
+        break;
+    }
+    }
+
+}
+
+void PointDataConversionPluginFactory::createPluginAndTransform(const PointDataConversionPlugin::Conversion& type, const mv::Dataset<mv::DatasetImpl>& inputDataset) const
+{
+    auto pluginInstance = dynamic_cast<PointDataConversionPlugin*>(plugins().requestPlugin(getKind()));
+
+    pluginInstance->setInputDataset(inputDataset);
+    pluginInstance->setConversion(type);
+    pluginInstance->setCofactor(getArcSinCoFactor());
+    pluginInstance->transform();
+
+}
+
+// =============================================================================
+// Helper
+// =============================================================================
+
+ConversionDialog::ConversionDialog(QWidget* parent, ToggleAction* sameFactorAction, DecimalAction* arcSinFactorAction, SlidersAction* arcSinFactorsAction) :
+    QDialog(parent), _conversionButton(this, "Convert")
+{
+    setWindowTitle(tr("Data conversion settings"));
+
+    connect(&_conversionButton, &TriggerAction::triggered, this, &ConversionDialog::closeDialogAction);
+
+    auto* layout = new QHBoxLayout();
+
+    auto groupAction = new GroupAction(this, "PointDataConversionGroupAction");
+
+    groupAction->setText("Settings");
+    groupAction->setToolTip("Data conversion settings");
+    groupAction->setLabelSizingType(GroupAction::LabelSizingType::Auto);
+    groupAction->addAction(sameFactorAction);
+    groupAction->addAction(arcSinFactorAction);
+    groupAction->addAction(arcSinFactorsAction);
+    groupAction->addAction(&_conversionButton);
+
+    layout->addWidget(groupAction->createWidget(this));
+    setLayout(layout);
 }

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -4,6 +4,7 @@
 
 #include <actions/PluginTriggerAction.h>
 
+#include <atomic>
 #include <cmath>
 
 #include <QDebug>
@@ -41,14 +42,17 @@ void PointDataConversionPlugin::transform()
     task.setProgressDescription(QString("%1 conversion").arg(getConversionName(_conversion)));
     
     points->visitData([this, &points, &task](auto pointData) {
-        std::uint64_t noPointsProcessed = 0;
+        std::atomic_uint64_t noPointsProcessed = 0;
     
-        float cofactor = _cofactors[0];
+        float cofactor          = _cofactors[0];
+        const auto numPointsF   = static_cast<float>(points->getNumPoints());
+        const auto numPointsI   = static_cast<std::int64_t>(points->getNumPoints());
+        const auto numDims      = points->getNumDimensions();
 
-        // TODO: parallelize the outer loop
-        for (std::uint64_t pointIndex = 0; pointIndex < points->getNumPoints(); pointIndex++) {
+#pragma omp parallel for
+        for (std::int64_t pointIndex = 0; pointIndex < numPointsI; pointIndex++) {
 
-            for (std::uint64_t dimensionIndex = 0; dimensionIndex < points->getNumDimensions(); dimensionIndex++) {
+            for (std::uint64_t dimensionIndex = 0; dimensionIndex < numDims; dimensionIndex++) {
                 switch (_conversion)
                 {
                 case Conversion::Log2:
@@ -61,11 +65,13 @@ void PointDataConversionPlugin::transform()
                 }
             }
 
-            // TODO: guard this when parallelizing
-            if (++noPointsProcessed % 1000 == 0) {
-                task.setProgress(static_cast<float>(noPointsProcessed) / static_cast<float>(points->getNumPoints()));
-
-                QApplication::processEvents();
+            if (const auto processed = ++noPointsProcessed;
+                processed % 1000 == 0) {
+#pragma omp critical
+                {
+                    task.setProgress(static_cast<float>(noPointsProcessed) / numPointsF);
+                    QApplication::processEvents();
+                }
             }
         }
 

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -20,7 +20,8 @@ const QMap<PointDataConversionPlugin::Conversion, QString> PointDataConversionPl
 
 PointDataConversionPlugin::PointDataConversionPlugin(const mv::plugin::PluginFactory* factory) :
     TransformationPlugin(factory),
-    _conversion(Conversion::ArcSin)
+    _conversion(Conversion::ArcSin),
+    _cofactors({5.f})
 {
 }
 
@@ -41,28 +42,33 @@ void PointDataConversionPlugin::transform()
     
     points->visitData([this, &points, &task](auto pointData) {
         std::uint64_t noPointsProcessed = 0;
-        for (auto point : pointData) {
+    
+        float cofactor = _cofactors[0];
+
+        // TODO: parallelize the outer loop
+        for (std::uint64_t pointIndex = 0; pointIndex < points->getNumPoints(); pointIndex++) {
+
             for (std::uint64_t dimensionIndex = 0; dimensionIndex < points->getNumDimensions(); dimensionIndex++) {
                 switch (_conversion)
                 {
-                    case Conversion::Log2:
-                        point[dimensionIndex] = std::log2f(point[dimensionIndex] + 1.0f);
-                        break;
-        
-                    case Conversion::ArcSin:
-                        point[dimensionIndex] = std::asinhf(point[dimensionIndex] / 5.0f);
-                        break;
+                case Conversion::Log2:
+                    pointData[pointIndex][dimensionIndex] = std::log2f(pointData[pointIndex][dimensionIndex] + 1.0f);
+                    break;
+
+                case Conversion::ArcSin:
+                    pointData[pointIndex][dimensionIndex] = std::asinhf(pointData[pointIndex][dimensionIndex] / cofactor);
+                    break;
                 }
             }
-        
-            ++noPointsProcessed;
-        
-            if (noPointsProcessed % 1000 == 0) {
+
+            // TODO: guard this when parallelizing
+            if (++noPointsProcessed % 1000 == 0) {
                 task.setProgress(static_cast<float>(noPointsProcessed) / static_cast<float>(points->getNumPoints()));
-                    
+
                 QApplication::processEvents();
             }
         }
+
     });
         
     task.setProgress(1.0f);
@@ -99,7 +105,7 @@ PointDataConversionPlugin* PointDataConversionPluginFactory::produce()
     return new PointDataConversionPlugin(this);
 }
 
-
+// TODO: add gui to optionally set per-channel cofactor
 PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(const mv::Datasets& datasets) const
 {
     PluginTriggerActions pluginTriggerActions;

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -155,6 +155,8 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
 
                     pluginInstance->setInputDataset(dataset);
                     pluginInstance->setConversion(type);
+                    pluginInstance->setCofactor(std::vector<float>{ _arcSinFactorAction.getValue() });
+
                     pluginInstance->transform();
                 }
             });
@@ -171,7 +173,6 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
     return pluginTriggerActions;
 }
 
-// TODO: actually use the cofactor
 WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const PointDataConversionPlugin::Conversion& type)
 {
     const auto createGroupAction = [this](WidgetAction& widgetAction) -> GroupAction* {

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -5,6 +5,7 @@
 #include <actions/PluginTriggerAction.h>
 
 #include <atomic>
+#include <cassert>
 #include <cmath>
 
 #include <QDebug>
@@ -46,12 +47,17 @@ void PointDataConversionPlugin::transform()
     points->visitData([this, &points, &task](auto pointData) {
         std::atomic_uint64_t noPointsProcessed = 0;
     
-        float cofactor          = _cofactors[0];
         const auto numPointsF   = static_cast<float>(points->getNumPoints());
         const auto numPointsI   = static_cast<std::int64_t>(points->getNumPoints());
         const auto numDims      = points->getNumDimensions();
 
-        qDebug() << "PointDataConversionPlugin::transform: cofactor of" << cofactor ;
+        assert(!_cofactors.empty());
+        assert(_cofactors.size() == 1 || _cofactors.size() == numDims);
+
+        if (_cofactors.size() == 1)
+            qDebug() << "PointDataConversionPlugin::transform: cofactor of" << _cofactors[0];
+        else
+            qDebug() << "PointDataConversionPlugin::transform: cofactors of" << _cofactors;
 
 #pragma omp parallel for
         for (std::int64_t pointIndex = 0; pointIndex < numPointsI; pointIndex++) {
@@ -64,6 +70,9 @@ void PointDataConversionPlugin::transform()
                     break;
 
                 case Conversion::ArcSin:
+
+                    const float cofactor = (_cofactors.size() == 1)  ? _cofactors[0] : _cofactors[dimensionIndex];
+
                     pointData[pointIndex][dimensionIndex] = std::asinhf(pointData[pointIndex][dimensionIndex] / cofactor);
                     break;
                 }

--- a/src/PointDataConversionPlugin.h
+++ b/src/PointDataConversionPlugin.h
@@ -47,6 +47,12 @@ public:
     /** Performs the data transformation */
     void transform() override;
 
+    /** Set the sinh cofactors */
+    void setCofactor(const std::vector<float>& cofactors) { _cofactors = cofactors; }
+
+    /** Set the sinh cofactors */
+    void setCofactor(std::vector<float> cofactors) { _cofactors = std::move(cofactors); }
+
     /**
      * Get point data conversion type
      * @return Point data conversion type

--- a/src/PointDataConversionPlugin.h
+++ b/src/PointDataConversionPlugin.h
@@ -5,11 +5,11 @@
 #include <Dataset.h>
 #include <TransformationPlugin.h>
 
-#include <QMap>
+#include "SlidersAction.h"
+
 #include <QString>
-
+#include <QStringList>
 #include <vector>
-
 
 /**
  * Point data conversion plugin class
@@ -121,5 +121,7 @@ private:
     std::vector<float> getArcSinCoFactor() const;
 
 private:
-    mv::gui::DecimalAction   _arcSinFactorAction;    /** Factor for arcsin(value/factor) conversion */
+    bool                    _sameCofactor = true;
+    mv::gui::DecimalAction  _arcSinFactorAction;       /** Factor for arcsin(value/factor) conversion */
+    mv::gui::SlidersAction  _arcSinFactorsAction;      /** Factor for arcsin(value/factor) conversion */
 };

--- a/src/PointDataConversionPlugin.h
+++ b/src/PointDataConversionPlugin.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <actions/DecimalAction.h>
+#include <actions/ToggleAction.h>
 
 #include <Dataset.h>
 #include <TransformationPlugin.h>
@@ -70,8 +71,8 @@ public:
     static QString getConversionName(const Conversion& conversion);
 
 private:
-    Conversion          _conversion;      /** Data conversion type */
-    std::vector<float>  _cofactors;
+    Conversion          _conversion = Conversion::ArcSin;
+    std::vector<float>  _cofactors = { 5.f };
 };
 
 /**
@@ -121,7 +122,7 @@ private:
     std::vector<float> getArcSinCoFactor() const;
 
 private:
-    bool                    _sameCofactor = true;
-    mv::gui::DecimalAction  _arcSinFactorAction;       /** Factor for arcsin(value/factor) conversion */
-    mv::gui::SlidersAction  _arcSinFactorsAction;      /** Factor for arcsin(value/factor) conversion */
+    mv::gui::ToggleAction  _sameFactorAction;
+    mv::gui::DecimalAction _arcSinFactorAction;
+    mv::gui::SlidersAction _arcSinFactorsAction;
 };

--- a/src/PointDataConversionPlugin.h
+++ b/src/PointDataConversionPlugin.h
@@ -1,8 +1,14 @@
 #pragma once
 
-#include <Dataset.h>
 #include <actions/DecimalAction.h>
+
+#include <Dataset.h>
 #include <TransformationPlugin.h>
+
+#include <QMap>
+#include <QString>
+
+#include <vector>
 
 using namespace mv::plugin;
 using namespace mv::gui;
@@ -20,12 +26,12 @@ class PointDataConversionPlugin : public TransformationPlugin
 public:
 
     /** Point data conversion type */
-    enum class Type {
+    enum class Conversion {
         Log2,       /** log2(value+1) */
         ArcSin      /** asinh(value/factor) */
     };
 
-    static const QMap<Type, QString> types;
+    static const QMap<Conversion, QString> CONVERSIONS;
 
 public:
 
@@ -45,27 +51,27 @@ public:
     void transform() override;
 
     /**
-    /**
      * Get point data conversion type
      * @return Point data conversion type
      */
-    Type getType() const;
+    Conversion getConversion() const;
 
     /**
      * Set point data conversion type
-     * @param type Point data conversion type
+     * @param conversion Point data conversion type
      */
-    void setType(const Type& type);
+    void setConversion(const Conversion& conversion);
 
     /**
      * Get string representation of type enum
-     * @param type Point data conversion type
-     * @return Type name
+     * @param conversion Point data conversion type
+     * @return conversion name
      */
-    static QString getTypeName(const Type& type);
+    static QString getConversionName(const Conversion& conversion);
 
 private:
-    Type    _type;      /** Data conversion type */
+    Conversion          _conversion;      /** Data conversion type */
+    std::vector<float>  _cofactors;
 };
 
 /**
@@ -100,7 +106,7 @@ public:
 
     /**
      * Get plugin trigger actions given \p dataTypes
-     * @param datasetTypes Vector of input data types
+     * @param dataTypes Vector of input data types
      * @return Vector of plugin trigger actions
      */
     PluginTriggerActions getPluginTriggerActions(const mv::DataTypes& dataTypes) const override;
@@ -109,7 +115,7 @@ public:
      * Get configuration action for \p type
      * @return Pointer to configuration action (may be null)
      */
-    WidgetAction* getConfigurationAction(const PointDataConversionPlugin::Type& type);
+    WidgetAction* getConfigurationAction(const PointDataConversionPlugin::Conversion& type);
 
 private:
     DecimalAction   _arcSinFactorAction;    /** Factor for arcsin(value/factor) conversion */

--- a/src/PointDataConversionPlugin.h
+++ b/src/PointDataConversionPlugin.h
@@ -42,7 +42,7 @@ public:
     ~PointDataConversionPlugin() override = default;
     
     /** Initialization is called when the plugin is first instantiated. */
-    void init() override {};
+    void init() override {}
 
     /** Performs the data transformation */
     void transform() override;
@@ -116,6 +116,9 @@ public:
      * @return Pointer to configuration action (may be null)
      */
     WidgetAction* getConfigurationAction(const PointDataConversionPlugin::Conversion& type);
+
+private:
+    std::vector<float> getArcSinCoFactor() const;
 
 private:
     mv::gui::DecimalAction   _arcSinFactorAction;    /** Factor for arcsin(value/factor) conversion */

--- a/src/PointDataConversionPlugin.h
+++ b/src/PointDataConversionPlugin.h
@@ -116,7 +116,7 @@ public:
      * Get configuration action for \p type
      * @return Pointer to configuration action (may be null)
      */
-    WidgetAction* getConfigurationAction(const PointDataConversionPlugin::Conversion& type);
+    WidgetAction* getConfigurationAction(const PointDataConversionPlugin::Conversion& type, const mv::Dataset<mv::DatasetImpl>& inputDataset);
 
 private:
     std::vector<float> getArcSinCoFactor() const;

--- a/src/PointDataConversionPlugin.h
+++ b/src/PointDataConversionPlugin.h
@@ -10,16 +10,13 @@
 
 #include <vector>
 
-using namespace mv::plugin;
-using namespace mv::gui;
-using namespace mv::util;
 
 /**
  * Point data conversion plugin class
  *
  * @author Thomas Kroes
  */
-class PointDataConversionPlugin : public TransformationPlugin
+class PointDataConversionPlugin : public mv::plugin::TransformationPlugin
 {
     Q_OBJECT
 
@@ -39,7 +36,7 @@ public:
      * Constructor
      * @param factory Pointer to the plugin factory
      */
-    PointDataConversionPlugin(const PluginFactory* factory);
+    PointDataConversionPlugin(const mv::plugin::PluginFactory* factory);
 
     /** Destructor */
     ~PointDataConversionPlugin() override = default;
@@ -79,7 +76,7 @@ private:
  *
  * @author Thomas Kroes
  */
-class PointDataConversionPluginFactory : public TransformationPluginFactory
+class PointDataConversionPluginFactory : public mv::plugin::TransformationPluginFactory
 {
     Q_INTERFACES(mv::plugin::TransformationPluginFactory mv::plugin::PluginFactory)
     Q_OBJECT
@@ -102,14 +99,14 @@ public:
      * @param datasets Vector of input datasets
      * @return Vector of plugin trigger actions
      */
-    PluginTriggerActions getPluginTriggerActions(const mv::Datasets& datasets) const override;
+    mv::gui::PluginTriggerActions getPluginTriggerActions(const mv::Datasets& datasets) const override;
 
     /**
      * Get plugin trigger actions given \p dataTypes
      * @param dataTypes Vector of input data types
      * @return Vector of plugin trigger actions
      */
-    PluginTriggerActions getPluginTriggerActions(const mv::DataTypes& dataTypes) const override;
+    mv::gui::PluginTriggerActions getPluginTriggerActions(const mv::DataTypes& dataTypes) const override;
 
     /**
      * Get configuration action for \p type
@@ -118,5 +115,5 @@ public:
     WidgetAction* getConfigurationAction(const PointDataConversionPlugin::Conversion& type);
 
 private:
-    DecimalAction   _arcSinFactorAction;    /** Factor for arcsin(value/factor) conversion */
+    mv::gui::DecimalAction   _arcSinFactorAction;    /** Factor for arcsin(value/factor) conversion */
 };

--- a/src/PointDataConversionPlugin.h
+++ b/src/PointDataConversionPlugin.h
@@ -116,7 +116,17 @@ public:
      * Get configuration action for \p type
      * @return Pointer to configuration action (may be null)
      */
-    WidgetAction* getConfigurationAction(const PointDataConversionPlugin::Conversion& type, const mv::Dataset<mv::DatasetImpl>& inputDataset);
+    WidgetAction* getConfigurationAction(const PointDataConversionPlugin::Conversion& type);
+
+    /**
+     * Show option dialog and run transform
+     */
+    void openConfigDialog(const PointDataConversionPlugin::Conversion& type, const mv::Dataset<mv::DatasetImpl>& inputDataset);
+
+    /**
+     * Create a transformation plugin and apply transformation
+     */
+    void createPluginAndTransform(const PointDataConversionPlugin::Conversion& type, const mv::Dataset<mv::DatasetImpl>& inputDataset) const;
 
 private:
     std::vector<float> getArcSinCoFactor() const;
@@ -125,4 +135,27 @@ private:
     mv::gui::ToggleAction  _sameFactorAction;
     mv::gui::DecimalAction _arcSinFactorAction;
     mv::gui::SlidersAction _arcSinFactorsAction;
+};
+
+/**
+ * Helper dialog to set conversion options
+ *
+ * @author Alex Vieth
+ */
+class ConversionDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit ConversionDialog(QWidget* parent, mv::gui::ToggleAction* sameFactorAction, mv::gui::DecimalAction* arcSinFactorAction, mv::gui::SlidersAction* arcSinFactorsAction);
+
+signals:
+    void closeDialog(bool onlyIndices);
+
+private slots:
+    void closeDialogAction() {
+        emit QDialog::accept();
+    }
+
+private:
+    mv::gui::TriggerAction _conversionButton;
 };

--- a/src/PointDataConversionPlugin.h
+++ b/src/PointDataConversionPlugin.h
@@ -48,9 +48,6 @@ public:
     void transform() override;
 
     /** Set the sinh cofactors */
-    void setCofactor(const std::vector<float>& cofactors) { _cofactors = cofactors; }
-
-    /** Set the sinh cofactors */
     void setCofactor(std::vector<float> cofactors) { _cofactors = std::move(cofactors); }
 
     /**

--- a/src/SlidersAction.cpp
+++ b/src/SlidersAction.cpp
@@ -51,6 +51,14 @@ void SlidersAction::setRangeForEntry(const QString& entry, float minimum, float 
     d.value = std::clamp(d.value, d.min, d.max);
 }
 
+void SlidersAction::setValueForAllEntries(float value)
+{
+    for (const auto& [name, data] : _entryData)
+        setValueForEntry(name, value);
+
+    setAllSlidersValues(value);
+}
+
 void SlidersAction::setValueForEntry(const QString& entry, float value) 
 {
     if (!_entryData.contains(entry)) return;
@@ -101,6 +109,22 @@ void SlidersAction::setAllSlidersEnabled(bool enabled)
 
 }
 
+void SlidersAction::setAllSlidersValues(float value)
+{
+    if (!_sliderList)
+        return;
+
+    for (int i = 0; i < _sliderList->count(); ++i) {
+        QListWidgetItem* item = _sliderList->item(i);
+        if (QWidget* row = _sliderList->itemWidget(item)) {
+            if (auto* slider = row->findChild<DecimalAction*>()) {
+                slider->setValue(value);
+            }
+        }
+    }
+
+}
+
 QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFlags) 
 {
     auto* container = new QWidget(parent);
@@ -122,7 +146,7 @@ QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFla
 
         const EntryData& d = _entryData.at(opt);
 
-        DecimalAction* slider = new DecimalAction(this, opt, d.min, d.max, d.value, EntryData::DEFAULT_DECIMALS);
+        DecimalAction* slider = new DecimalAction(row, opt, d.min, d.max, d.value, EntryData::DEFAULT_DECIMALS);
         rowLayout->addWidget(slider->createLabelWidget(container));
         rowLayout->addWidget(slider->createWidget(container));
 

--- a/src/SlidersAction.cpp
+++ b/src/SlidersAction.cpp
@@ -14,65 +14,73 @@ SlidersAction::SlidersAction(QObject* parent, const QString& title) :
     setDefaultWidgetFlags(SlidersAction::DisableOnFirstOpen);
 }
 
-void SlidersAction::initialize(const QStringList& options) {
-    setOptions(options);
+void SlidersAction::initialize(const QStringList& entries) {
+    setEntries(entries);
+    setAllEntriesToDefault();
 }
 
-void SlidersAction::setOptions(const QStringList& options) {
-    _options = options;
-    // populate default OptionData if new
-    for (const QString& opt : options) {
-        if (!_optionData.contains(opt)) {
-            _optionData.insert({ opt, OptionData{} });
+void SlidersAction::setEntries(const QStringList& entries) {
+    _entries = entries;
+    // populate default EntryData if new
+    for (const QString& opt : entries) {
+        if (!_entryData.contains(opt)) {
+            _entryData.insert({ opt, EntryData{} });
         }
     }
-    // remove data for removed options
-    for (auto it = _optionData.begin(); it != _optionData.end(); ) {
-        if (!options.contains(it->first))
-            it = _optionData.erase(it);
+    // remove data for removed entries
+    for (auto it = _entryData.begin(); it != _entryData.end(); ) {
+        if (!entries.contains(it->first))
+            it = _entryData.erase(it);
         else ++it;
     }
 }
 
-void SlidersAction::setRangeForOption(const QString& option, float minimum, float maximum) 
+void SlidersAction::setAllEntriesToDefault()
 {
-    if (!_optionData.contains(option)) return;
-    auto& d = _optionData[option];
+    for (const auto& [name, data] : _entryData)
+        setDataForEntry(name, 5.f, 0.f, 100.f);
+
+}
+
+void SlidersAction::setRangeForEntry(const QString& entry, float minimum, float maximum) 
+{
+    if (!_entryData.contains(entry)) return;
+    auto& d = _entryData[entry];
     d.min = minimum;
     d.max = maximum;
     d.value = std::clamp(d.value, d.min, d.max);
 }
 
-void SlidersAction::setValueForOption(const QString& option, float value) 
+void SlidersAction::setValueForEntry(const QString& entry, float value) 
 {
-    if (!_optionData.contains(option)) return;
-    auto& d = _optionData[option];
+    if (!_entryData.contains(entry)) return;
+    auto& d = _entryData[entry];
     value = std::clamp(value, d.min, d.max);
     if (std::abs(d.value - value) < 0.0001f) return;
     d.value = value;
-    emit optionValueChanged(option, value);
+    emit entryValueChanged(entry, value);
 }
 
-void SlidersAction::setDataForOption(const QString& option, float value, float minimum, float maximum) 
+void SlidersAction::setDataForEntry(const QString& entry, float value, float minimum, float maximum) 
 {
-    setRangeForOption(option, minimum, maximum);
-    setValueForOption(option, value);
+    setRangeForEntry(entry, minimum, maximum);
+    setValueForEntry(entry, value);
 }
 
-float SlidersAction::getValueForOption(const QString& option) const 
+float SlidersAction::getValueForEntry(const QString& entry) const 
 {
-    if (!_optionData.contains(option))
+    if (!_entryData.contains(entry))
         return 0.0f;
-    return _optionData.at(option).value;
+    return _entryData.at(entry).value;
 }
 
 std::vector<float> SlidersAction::getValues() const
 {
     std::vector<float> values;
-    values.reserve(_options.size());
+    values.reserve(_entries.size());
 
-    for (const auto& opt : _options)
-        values.push_back(getValueForOption(opt));
+    for (const auto& opt : _entries)
+        values.push_back(getValueForEntry(opt));
 
     return values;
 }
@@ -105,16 +113,16 @@ QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFla
     _sliderList->setSelectionMode(QAbstractItemView::NoSelection);
     layout->addWidget(_sliderList);
 
-    for (const QString& opt : _options) {
+    for (const QString& opt : _entries) {
         auto* item = new QListWidgetItem(_sliderList);
 
         QWidget* row = new QWidget(_sliderList);
         QHBoxLayout* rowLayout = new QHBoxLayout(row);
         rowLayout->setContentsMargins(2, 2, 2, 2);
 
-        const OptionData& d = _optionData.at(opt);
+        const EntryData& d = _entryData.at(opt);
 
-        DecimalAction* slider = new DecimalAction(this, opt, d.min, d.max, d.value, OptionData::DEFAULT_DECIMALS);
+        DecimalAction* slider = new DecimalAction(this, opt, d.min, d.max, d.value, EntryData::DEFAULT_DECIMALS);
         rowLayout->addWidget(slider->createLabelWidget(container));
         rowLayout->addWidget(slider->createWidget(container));
 
@@ -123,7 +131,7 @@ QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFla
         item->setSizeHint(row->sizeHint());
 
         connect(slider, &DecimalAction::valueChanged, this, [this, opt](float value) {
-            setValueForOption(opt, value);
+            setValueForEntry(opt, value);
             });
     }
 

--- a/src/SlidersAction.cpp
+++ b/src/SlidersAction.cpp
@@ -1,0 +1,111 @@
+#include "SlidersAction.h"
+
+#include <actions/DecimalAction.h>
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidgetItem>
+
+using namespace mv::gui;
+
+SlidersAction::SlidersAction(QObject* parent, const QString& title) :
+    WidgetAction(parent, title)
+{
+    setText(title);
+    setDefaultWidgetFlags(SlidersAction::Default);
+}
+
+void SlidersAction::initialize(const QStringList& options) {
+    setOptions(options);
+}
+
+void SlidersAction::setOptions(const QStringList& options) {
+    _options = options;
+    // populate default OptionData if new
+    for (const QString& opt : options) {
+        if (!_optionData.contains(opt)) {
+            _optionData.insert({ opt, OptionData{} });
+        }
+    }
+    // remove data for removed options
+    for (auto it = _optionData.begin(); it != _optionData.end(); ) {
+        if (!options.contains(it->first))
+            it = _optionData.erase(it);
+        else ++it;
+    }
+}
+
+void SlidersAction::setRangeForOption(const QString& option, float minimum, float maximum) {
+    if (!_optionData.contains(option)) return;
+    auto& d = _optionData[option];
+    d.min = minimum;
+    d.max = maximum;
+    d.value = std::clamp(d.value, d.min, d.max);
+}
+
+void SlidersAction::setValueForOption(const QString& option, float value) {
+    if (!_optionData.contains(option)) return;
+    auto& d = _optionData[option];
+    value = std::clamp(value, d.min, d.max);
+    if (d.value == value) return;
+    d.value = value;
+    emit optionValueChanged(option, value);
+}
+
+void SlidersAction::setDataForOption(const QString& option, float value, float minimum, float maximum) {
+    if (!_optionData.contains(option)) return;
+    auto& d = _optionData[option];
+    d.min = minimum; 
+    d.max = maximum;
+    value = std::clamp(value, d.min, d.max);
+    if (d.value == value) return;
+    d.value = value;
+    emit optionValueChanged(option, value);
+}
+
+float SlidersAction::getValueForOption(const QString& option) const {
+    if (!_optionData.contains(option)) return 0.0f;
+    return _optionData.at(option).value;
+}
+
+std::vector<float> SlidersAction::getValues() const
+{
+    std::vector<float> values;
+    values.reserve(_options.size());
+
+    for (const auto& opt : _options)
+        values.push_back(getValueForOption(opt));
+
+    return values;
+}
+
+QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFlags) {
+    // Create a popup list widget with rows; each row contains a checkbox, label, slider, spinbox.
+    auto* container = new QWidget(parent);
+    auto* layout = new QVBoxLayout(container);
+    layout->setContentsMargins(4, 4, 4, 4);
+
+    auto* list = new QListWidget(container);
+    list->setSelectionMode(QAbstractItemView::NoSelection);
+    layout->addWidget(list);
+
+    for (const QString& opt : _options) {
+        auto* item = new QListWidgetItem(list);
+
+        QWidget* row = new QWidget(list);
+        QHBoxLayout* rowLayout = new QHBoxLayout(row);
+        rowLayout->setContentsMargins(2, 2, 2, 2);
+
+        const OptionData& d = _optionData.at(opt);
+
+        DecimalAction* slider = new DecimalAction(this, opt, d.min, d.max, d.value, 2);
+        rowLayout->addWidget(slider->createLabelWidget(container));
+        rowLayout->addWidget(slider->createWidget(container));
+
+        list->addItem(item);
+        list->setItemWidget(item, row);
+        item->setSizeHint(row->sizeHint());
+    }
+
+    return container;
+}

--- a/src/SlidersAction.cpp
+++ b/src/SlidersAction.cpp
@@ -11,7 +11,7 @@ SlidersAction::SlidersAction(QObject* parent, const QString& title) :
     WidgetAction(parent, title)
 {
     setText(title);
-    setDefaultWidgetFlags(SlidersAction::Default);
+    setDefaultWidgetFlags(SlidersAction::DisableOnFirstOpen);
 }
 
 void SlidersAction::initialize(const QStringList& options) {
@@ -99,6 +99,8 @@ QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFla
     auto* layout = new QVBoxLayout(container);
     layout->setContentsMargins(4, 4, 4, 4);
 
+    const bool disableAll = _sliderList == nullptr && widgetFlags == WidgetFlag::DisableOnFirstOpen;
+
     _sliderList = new QListWidget(container);
     _sliderList->setSelectionMode(QAbstractItemView::NoSelection);
     layout->addWidget(_sliderList);
@@ -124,6 +126,9 @@ QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFla
             setValueForOption(opt, value);
             });
     }
+
+    if (disableAll)
+        setAllSlidersEnabled(false);
 
     return container;
 }

--- a/src/SlidersAction.cpp
+++ b/src/SlidersAction.cpp
@@ -4,7 +4,6 @@
 
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QListWidgetItem>
 
 using namespace mv::gui;
 
@@ -78,20 +77,36 @@ std::vector<float> SlidersAction::getValues() const
     return values;
 }
 
+void SlidersAction::setAllSlidersEnabled(bool enabled)
+{
+    setEnabled(enabled);
+
+    if (!_sliderList)
+        return;
+
+    for (int i = 0; i < _sliderList->count(); ++i) {
+        QListWidgetItem* item = _sliderList->item(i);
+        if (QWidget* row = _sliderList->itemWidget(item)) {
+            row->setEnabled(enabled);
+        }
+    }
+
+}
+
 QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFlags) 
 {
     auto* container = new QWidget(parent);
     auto* layout = new QVBoxLayout(container);
     layout->setContentsMargins(4, 4, 4, 4);
 
-    auto* list = new QListWidget(container);
-    list->setSelectionMode(QAbstractItemView::NoSelection);
-    layout->addWidget(list);
+    _sliderList = new QListWidget(container);
+    _sliderList->setSelectionMode(QAbstractItemView::NoSelection);
+    layout->addWidget(_sliderList);
 
     for (const QString& opt : _options) {
-        auto* item = new QListWidgetItem(list);
+        auto* item = new QListWidgetItem(_sliderList);
 
-        QWidget* row = new QWidget(list);
+        QWidget* row = new QWidget(_sliderList);
         QHBoxLayout* rowLayout = new QHBoxLayout(row);
         rowLayout->setContentsMargins(2, 2, 2, 2);
 
@@ -101,8 +116,8 @@ QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFla
         rowLayout->addWidget(slider->createLabelWidget(container));
         rowLayout->addWidget(slider->createWidget(container));
 
-        list->addItem(item);
-        list->setItemWidget(item, row);
+        _sliderList->addItem(item);
+        _sliderList->setItemWidget(item, row);
         item->setSizeHint(row->sizeHint());
 
         connect(slider, &DecimalAction::valueChanged, this, [this, opt](float value) {

--- a/src/SlidersAction.cpp
+++ b/src/SlidersAction.cpp
@@ -35,7 +35,8 @@ void SlidersAction::setOptions(const QStringList& options) {
     }
 }
 
-void SlidersAction::setRangeForOption(const QString& option, float minimum, float maximum) {
+void SlidersAction::setRangeForOption(const QString& option, float minimum, float maximum) 
+{
     if (!_optionData.contains(option)) return;
     auto& d = _optionData[option];
     d.min = minimum;
@@ -43,28 +44,26 @@ void SlidersAction::setRangeForOption(const QString& option, float minimum, floa
     d.value = std::clamp(d.value, d.min, d.max);
 }
 
-void SlidersAction::setValueForOption(const QString& option, float value) {
+void SlidersAction::setValueForOption(const QString& option, float value) 
+{
     if (!_optionData.contains(option)) return;
     auto& d = _optionData[option];
     value = std::clamp(value, d.min, d.max);
-    if (d.value == value) return;
+    if (std::abs(d.value - value) < 0.0001f) return;
     d.value = value;
     emit optionValueChanged(option, value);
 }
 
-void SlidersAction::setDataForOption(const QString& option, float value, float minimum, float maximum) {
-    if (!_optionData.contains(option)) return;
-    auto& d = _optionData[option];
-    d.min = minimum; 
-    d.max = maximum;
-    value = std::clamp(value, d.min, d.max);
-    if (d.value == value) return;
-    d.value = value;
-    emit optionValueChanged(option, value);
+void SlidersAction::setDataForOption(const QString& option, float value, float minimum, float maximum) 
+{
+    setRangeForOption(option, minimum, maximum);
+    setValueForOption(option, value);
 }
 
-float SlidersAction::getValueForOption(const QString& option) const {
-    if (!_optionData.contains(option)) return 0.0f;
+float SlidersAction::getValueForOption(const QString& option) const 
+{
+    if (!_optionData.contains(option))
+        return 0.0f;
     return _optionData.at(option).value;
 }
 
@@ -79,8 +78,8 @@ std::vector<float> SlidersAction::getValues() const
     return values;
 }
 
-QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFlags) {
-    // Create a popup list widget with rows; each row contains a checkbox, label, slider, spinbox.
+QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFlags) 
+{
     auto* container = new QWidget(parent);
     auto* layout = new QVBoxLayout(container);
     layout->setContentsMargins(4, 4, 4, 4);
@@ -98,13 +97,17 @@ QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFla
 
         const OptionData& d = _optionData.at(opt);
 
-        DecimalAction* slider = new DecimalAction(this, opt, d.min, d.max, d.value, 2);
+        DecimalAction* slider = new DecimalAction(this, opt, d.min, d.max, d.value, OptionData::DEFAULT_DECIMALS);
         rowLayout->addWidget(slider->createLabelWidget(container));
         rowLayout->addWidget(slider->createWidget(container));
 
         list->addItem(item);
         list->setItemWidget(item, row);
         item->setSizeHint(row->sizeHint());
+
+        connect(slider, &DecimalAction::valueChanged, this, [this, opt](float value) {
+            setValueForOption(opt, value);
+            });
     }
 
     return container;

--- a/src/SlidersAction.h
+++ b/src/SlidersAction.h
@@ -24,7 +24,7 @@ namespace mv::gui {
         };
 
     public:
-        struct OptionData {
+        struct EntryData {
             static constexpr float DEFAULT_MIN = 1.0f;
             static constexpr float DEFAULT_MAX = 100.0f;
             static constexpr float DEFAULT_VALUE = 5.0f;
@@ -38,26 +38,27 @@ namespace mv::gui {
     public:
         explicit SlidersAction(QObject* parent, const QString& title);
 
-        void initialize(const QStringList& options = QStringList());
-        void setOptions(const QStringList& options);
+        void initialize(const QStringList& entries = QStringList());
+        void setEntries(const QStringList& entries);
+        void setAllEntriesToDefault();
 
-        void setRangeForOption(const QString& option, float minimum, float maximum);
-        void setValueForOption(const QString& option, float value);
-        void setDataForOption(const QString& option, float value, float minimum, float maximum);
-        [[nodiscard]] float getValueForOption(const QString& option) const;
+        void setRangeForEntry(const QString& entry, float minimum, float maximum);
+        void setValueForEntry(const QString& entry, float value);
+        void setDataForEntry(const QString& entry, float value, float minimum, float maximum);
+        [[nodiscard]] float getValueForEntry(const QString& entry) const;
         [[nodiscard]] std::vector<float> getValues() const;
 
         void setAllSlidersEnabled(bool enabled);
 
     signals:
-        void optionValueChanged(const QString& option, float value);
+        void entryValueChanged(const QString& entry, float value);
 
     protected:
         QWidget* getWidget(QWidget* parent, const std::int32_t& widgetFlags) override;
 
     private:
-        QStringList _options = {};
-        std::unordered_map<QString, OptionData> _optionData = {};
+        QStringList _entries = {};
+        std::unordered_map<QString, EntryData> _entryData = {};
         QListWidget* _sliderList = nullptr;
     };
 }

--- a/src/SlidersAction.h
+++ b/src/SlidersAction.h
@@ -14,13 +14,27 @@ namespace mv::gui {
 
     class SlidersAction : public WidgetAction {
         Q_OBJECT
-    public:
-        explicit SlidersAction(QObject* parent, const QString& title);
 
+    public:
         /** Describes the widget flags */
         enum WidgetFlag {
             Default = 0x00001,
         };
+
+    public:
+        struct OptionData {
+            static constexpr float DEFAULT_MIN = 1.0f;
+            static constexpr float DEFAULT_MAX = 100.0f;
+            static constexpr float DEFAULT_VALUE = 5.0f;
+            static constexpr std::int32_t DEFAULT_DECIMALS = 2;
+
+            float min = DEFAULT_MIN;
+            float max = DEFAULT_MAX;
+            float value = DEFAULT_VALUE;
+        };
+
+    public:
+        explicit SlidersAction(QObject* parent, const QString& title);
 
         void initialize(const QStringList& options = QStringList());
         void setOptions(const QStringList& options);
@@ -38,11 +52,6 @@ namespace mv::gui {
         QWidget* getWidget(QWidget* parent, const std::int32_t& widgetFlags) override;
 
     private:
-        struct OptionData {
-            float min = 0.0f;
-            float max = 1.0f;
-            float value = 0.5f;
-        };
 
         QStringList _options = {};
         std::unordered_map<QString, OptionData> _optionData = {};

--- a/src/SlidersAction.h
+++ b/src/SlidersAction.h
@@ -44,11 +44,13 @@ namespace mv::gui {
 
         void setRangeForEntry(const QString& entry, float minimum, float maximum);
         void setValueForEntry(const QString& entry, float value);
+        void setValueForAllEntries(float value); // also updates sliders
         void setDataForEntry(const QString& entry, float value, float minimum, float maximum);
         [[nodiscard]] float getValueForEntry(const QString& entry) const;
         [[nodiscard]] std::vector<float> getValues() const;
 
         void setAllSlidersEnabled(bool enabled);
+        void setAllSlidersValues(float value);
 
     signals:
         void entryValueChanged(const QString& entry, float value);
@@ -60,5 +62,6 @@ namespace mv::gui {
         QStringList _entries = {};
         std::unordered_map<QString, EntryData> _entryData = {};
         QListWidget* _sliderList = nullptr;
+
     };
 }

--- a/src/SlidersAction.h
+++ b/src/SlidersAction.h
@@ -20,6 +20,7 @@ namespace mv::gui {
         /** Describes the widget flags */
         enum WidgetFlag {
             Default = 0x00001,
+            DisableOnFirstOpen = 0x00002,
         };
 
     public:

--- a/src/SlidersAction.h
+++ b/src/SlidersAction.h
@@ -2,6 +2,7 @@
 
 #include <actions/WidgetAction.h>
 
+#include <QListWidget>
 #include <QString>
 #include <QStringList>
 #include <QWidget>
@@ -45,6 +46,8 @@ namespace mv::gui {
         [[nodiscard]] float getValueForOption(const QString& option) const;
         [[nodiscard]] std::vector<float> getValues() const;
 
+        void setAllSlidersEnabled(bool enabled);
+
     signals:
         void optionValueChanged(const QString& option, float value);
 
@@ -52,8 +55,8 @@ namespace mv::gui {
         QWidget* getWidget(QWidget* parent, const std::int32_t& widgetFlags) override;
 
     private:
-
         QStringList _options = {};
         std::unordered_map<QString, OptionData> _optionData = {};
+        QListWidget* _sliderList = nullptr;
     };
 }

--- a/src/SlidersAction.h
+++ b/src/SlidersAction.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <actions/WidgetAction.h>
+
+#include <QString>
+#include <QStringList>
+#include <QWidget>
+
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace mv::gui {
+
+    class SlidersAction : public WidgetAction {
+        Q_OBJECT
+    public:
+        explicit SlidersAction(QObject* parent, const QString& title);
+
+        /** Describes the widget flags */
+        enum WidgetFlag {
+            Default = 0x00001,
+        };
+
+        void initialize(const QStringList& options = QStringList());
+        void setOptions(const QStringList& options);
+
+        void setRangeForOption(const QString& option, float minimum, float maximum);
+        void setValueForOption(const QString& option, float value);
+        void setDataForOption(const QString& option, float value, float minimum, float maximum);
+        [[nodiscard]] float getValueForOption(const QString& option) const;
+        [[nodiscard]] std::vector<float> getValues() const;
+
+    signals:
+        void optionValueChanged(const QString& option, float value);
+
+    protected:
+        QWidget* getWidget(QWidget* parent, const std::int32_t& widgetFlags) override;
+
+    private:
+        struct OptionData {
+            float min = 0.0f;
+            float max = 1.0f;
+            float value = 0.5f;
+        };
+
+        QStringList _options = {};
+        std::unordered_map<QString, OptionData> _optionData = {};
+    };
+}


### PR DESCRIPTION
Adds the option to set individual cofactors for each data dimension for the `asinh` transformation.

UI for data set based plugin entry point (e.g. right-click in the data hierarchy):
<img width="676" height="367" alt="image" src="https://github.com/user-attachments/assets/dfa45e52-4009-4751-8f08-eaef6c6ce6d7" />

UI for data type based plugin entry point (e.g. via the image loader):
<img width="245" height="99" alt="image" src="https://github.com/user-attachments/assets/dc2fb31d-b38f-4c6b-8132-23b3115d67fc" />
This data type entry point does not allow for channel-wise cofactors since we do not yet know of the number of data channels when the settings UI (`pluginTriggerAction->setConfigurationAction` is setup). 

Additional:
- Parallel transformation with OpenMP
- Small refactors: clearer names that do not shadow other ManiVault names (`PointDataConversionPlugin::Type` -> `PointDataConversionPlugin::Conversion`)