### PR TITLE
Fix Default settings for data-type plugin construction

### DIFF
--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -32,10 +32,10 @@ const QMap<PointDataConversionPlugin::Conversion, QString> PointDataConversionPl
 
 static constexpr float COFACTOR_MIN = 1.0f;
 static constexpr float COFACTOR_MAX = 100.0f;
-static constexpr float COFACTOR_VALUE = 5.0f;
+static constexpr float COFACTOR_DEFAULT = 5.0f;
 static constexpr float PERCENTILE_MIN = 0.0f;
 static constexpr float PERCENTILE_MAX = 100.0f;
-static constexpr float PERCENTILE_VALUE = 99.0f;
+static constexpr float PERCENTILE_DEFAULT = 99.0f;
 
 PointDataConversionPlugin::PointDataConversionPlugin(const mv::plugin::PluginFactory* factory) :
     TransformationPlugin(factory)
@@ -72,7 +72,7 @@ void PointDataConversionPlugin::transform()
         // Some conversions require a preparation step
         switch (_conversion)
         {
-        case Conversion::Log2: break;
+        case Conversion::Log2: [[fallthrough]];
         case Conversion::Log1p: break;
         case Conversion::ArcSinh:  
             
@@ -184,8 +184,8 @@ PointDataConversionPluginFactory::PointDataConversionPluginFactory() :
     _percentileAction.setToolTip("Apply the same percentile to each channel.");
     _percentilesAction.setToolTip("Apply different percentiles to each channel.");
 
-    _arcSinFactorAction.initialize(COFACTOR_MIN, COFACTOR_MAX, COFACTOR_VALUE, SlidersAction::DEFAULT_DECIMALS);
-    _percentileAction.initialize(PERCENTILE_MIN, PERCENTILE_MAX, PERCENTILE_VALUE, SlidersAction::DEFAULT_DECIMALS);
+    _arcSinFactorAction.initialize(COFACTOR_MIN, COFACTOR_MAX, COFACTOR_DEFAULT, SlidersAction::DEFAULT_DECIMALS);
+    _percentileAction.initialize(PERCENTILE_MIN, PERCENTILE_MAX, PERCENTILE_DEFAULT, SlidersAction::DEFAULT_DECIMALS);
 
     connect(&_sameChannelSettingAction, &ToggleAction::toggled, this, [&](bool toggled)
         {
@@ -405,16 +405,16 @@ void PointDataConversionPluginFactory::setConfigDialogDefaultSettings(const Poin
 
     case PointDataConversionPlugin::Conversion::ArcSinh:
     {
-        _arcSinFactorAction.setValue(5.f);
+        _arcSinFactorAction.setValue(COFACTOR_DEFAULT);
         _arcSinFactorsAction.setEntries(dimensionNames);
-        _arcSinFactorsAction.setValueForAllEntries(5.f);
+        _arcSinFactorsAction.setValueForAllEntries(COFACTOR_DEFAULT);
         break;
     }
     case PointDataConversionPlugin::Conversion::ClampMax:
     {
-        _percentileAction.setValue(99.f);
+        _percentileAction.setValue(PERCENTILE_DEFAULT);
         _percentilesAction.setEntries(dimensionNames);
-        _percentilesAction.setValueForAllEntries(99.f);
+        _percentilesAction.setValueForAllEntries(PERCENTILE_DEFAULT);
         break;
     }
 

--- a/src/PointDataConversionPlugin.cpp
+++ b/src/PointDataConversionPlugin.cpp
@@ -30,6 +30,13 @@ const QMap<PointDataConversionPlugin::Conversion, QString> PointDataConversionPl
     { Conversion::ClampMax, "Clamp (max)" }
     });
 
+static constexpr float COFACTOR_MIN = 1.0f;
+static constexpr float COFACTOR_MAX = 100.0f;
+static constexpr float COFACTOR_VALUE = 5.0f;
+static constexpr float PERCENTILE_MIN = 0.0f;
+static constexpr float PERCENTILE_MAX = 100.0f;
+static constexpr float PERCENTILE_VALUE = 99.0f;
+
 PointDataConversionPlugin::PointDataConversionPlugin(const mv::plugin::PluginFactory* factory) :
     TransformationPlugin(factory)
 {
@@ -167,33 +174,50 @@ QString PointDataConversionPlugin::getConversionName(const Conversion& conversio
 
 PointDataConversionPluginFactory::PointDataConversionPluginFactory() :
     _sameChannelSettingAction(this, "Same factor", true),
-    _singleDecimalSettingAction(this, "Factor"),
-    _channelWiseDecimalAction(this, "Factors")
+    _arcSinFactorAction(this, "Cofactor"),
+    _arcSinFactorsAction(this, "Cofactors"),
+    _percentileAction(this, "Percentile"),
+    _percentilesAction(this, "Percentiles")
 {
-    _singleDecimalSettingAction.setToolTip("Apply the same cofactors to each channel.");
-    _channelWiseDecimalAction.setToolTip("Apply different cofactors to each channel.");
+    _arcSinFactorAction.setToolTip("Apply the same cofactor to each channel.");
+    _arcSinFactorsAction.setToolTip("Apply different cofactors to each channel.");
+    _percentileAction.setToolTip("Apply the same percentile to each channel.");
+    _percentilesAction.setToolTip("Apply different percentiles to each channel.");
 
-    _singleDecimalSettingAction.initialize(SlidersAction::EntryData::DEFAULT_MIN, SlidersAction::EntryData::DEFAULT_MAX,
-        SlidersAction::EntryData::DEFAULT_VALUE, SlidersAction::EntryData::DEFAULT_DECIMALS);
+    _arcSinFactorAction.initialize(COFACTOR_MIN, COFACTOR_MAX, COFACTOR_VALUE, SlidersAction::DEFAULT_DECIMALS);
+    _percentileAction.initialize(PERCENTILE_MIN, PERCENTILE_MAX, PERCENTILE_VALUE, SlidersAction::DEFAULT_DECIMALS);
 
     connect(&_sameChannelSettingAction, &ToggleAction::toggled, this, [&](bool toggled)
         {
-            _singleDecimalSettingAction.setEnabled(_sameChannelSettingAction.isChecked());
-            _channelWiseDecimalAction.setAllSlidersEnabled(!_sameChannelSettingAction.isChecked());
+            _arcSinFactorAction.setEnabled(_sameChannelSettingAction.isChecked());
+            _arcSinFactorsAction.setAllSlidersEnabled(!_sameChannelSettingAction.isChecked());
+
+            _percentileAction.setEnabled(_sameChannelSettingAction.isChecked());
+            _percentilesAction.setAllSlidersEnabled(!_sameChannelSettingAction.isChecked());
         });
 
-    connect(&_singleDecimalSettingAction, &DecimalAction::valueChanged, this, [&](float value)
-        {
-            const auto sliderValues = _channelWiseDecimalAction.getValues();
-            
-            const bool allEqual = !sliderValues.empty() &&
+    auto passValueToMultiChannelSettings = [](const float value, mv::gui::SlidersAction& multiChannelAction)
+    {
+        const auto sliderValues = multiChannelAction.getValues();
+
+        const bool allEqual = !sliderValues.empty() &&
             std::all_of(sliderValues.cbegin() + 1, sliderValues.cend(),
                 [&](const float v) { return std::abs(v - sliderValues.front()) < 0.0001f; });
 
-            if (!allEqual)
-                return;
+        if (!allEqual)
+            return;
 
-            _channelWiseDecimalAction.setValueForAllEntries(value);
+        multiChannelAction.setValueForAllEntries(value);
+    };
+
+    connect(&_arcSinFactorAction, &DecimalAction::valueChanged, this, [&, passValueToMultiChannelSettings](const float value)
+        {
+            passValueToMultiChannelSettings(value, _arcSinFactorsAction);
+        });
+
+    connect(&_percentileAction, &DecimalAction::valueChanged, this, [&, passValueToMultiChannelSettings](const float value)
+        {
+            passValueToMultiChannelSettings(value, _percentilesAction);
         });
 
 }
@@ -203,12 +227,36 @@ PointDataConversionPlugin* PointDataConversionPluginFactory::produce()
     return new PointDataConversionPlugin(this);
 }
 
-std::vector<float> PointDataConversionPluginFactory::getConversionSetting() const
+std::vector<float> PointDataConversionPluginFactory::getConversionSetting(const PointDataConversionPlugin::Conversion& conversion) const
 {
-    if (_sameChannelSettingAction.isChecked())
-        return { _singleDecimalSettingAction.getValue() };
+    std::vector<float> setting = { -1.f };
 
-    return _channelWiseDecimalAction.getValues();
+    switch (conversion)
+    {
+    case PointDataConversionPlugin::Conversion::Log2:
+        [[fallthrough]];
+    case PointDataConversionPlugin::Conversion::Log1p:
+        break;
+
+    case PointDataConversionPlugin::Conversion::ArcSinh:
+    {
+        setting = (_sameChannelSettingAction.isChecked() ) 
+            ? std::vector<float>{ _arcSinFactorAction.getValue() } 
+            : _arcSinFactorsAction.getValues();
+
+        break;
+    }
+    case PointDataConversionPlugin::Conversion::ClampMax:
+    {
+        setting = (_sameChannelSettingAction.isChecked())
+            ? std::vector<float>{ _percentileAction.getValue() }
+            : _percentilesAction.getValues();
+
+        break;
+    }
+    }
+
+    return setting;
 }
 
 PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(const mv::Datasets& datasets) const
@@ -268,9 +316,7 @@ PluginTriggerActions PointDataConversionPluginFactory::getPluginTriggerActions(c
 
 WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const PointDataConversionPlugin::Conversion& type)
 {
-    const auto createGroupAction = [this]() -> GroupAction* {
-
-        _channelWiseDecimalAction.initialize({});
+    const auto createGroupAction = [this](mv::gui::DecimalAction& singleDecimalSettingAction) -> GroupAction* {
         _sameChannelSettingAction.setChecked(true);
 
         auto groupAction = new GroupAction(this, "PointDataConversionGroupAction");
@@ -278,13 +324,13 @@ WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const Poi
         groupAction->setText("Settings");
         groupAction->setToolTip("Data conversion settings");
         groupAction->setLabelSizingType(GroupAction::LabelSizingType::Auto);
-        groupAction->addAction(&_singleDecimalSettingAction);
+        groupAction->addAction(&singleDecimalSettingAction);
 
         return groupAction;
     };
 
     WidgetAction* configAction = nullptr;
-    setConfigDialogDefaultSettings(type);
+    setConfigDialogDefaultSettings(type, {});
 
     switch (type)
     {
@@ -294,10 +340,13 @@ WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const Poi
             break;
 
         case PointDataConversionPlugin::Conversion::ArcSinh: 
-            [[fallthrough]];
+        {
+            configAction = createGroupAction(_arcSinFactorAction);
+            break;
+        }
         case PointDataConversionPlugin::Conversion::ClampMax:
         {
-            configAction = createGroupAction();
+            configAction = createGroupAction(_percentileAction);
             break;
         }
     }
@@ -307,12 +356,11 @@ WidgetAction* PointDataConversionPluginFactory::getConfigurationAction(const Poi
 
 void PointDataConversionPluginFactory::openConfigDialog(const PointDataConversionPlugin::Conversion& type, const mv::Dataset<mv::DatasetImpl>& inputDataset)
 {
-    _sameChannelSettingAction.setChecked(true);
     const std::vector<QString> dimNamesVec = mv::Dataset<Points>(inputDataset)->getDimensionNames();
     const QStringList dimNamesList(dimNamesVec.begin(), dimNamesVec.end());
-    _channelWiseDecimalAction.initialize(dimNamesList);
 
-    setConfigDialogDefaultSettings(type);
+    setConfigDialogDefaultSettings(type, dimNamesList);
+    _sameChannelSettingAction.setChecked(true);
 
     switch (type)
     {
@@ -325,7 +373,7 @@ void PointDataConversionPluginFactory::openConfigDialog(const PointDataConversio
     case PointDataConversionPlugin::Conversion::ArcSinh:
     {
         ConversionDialog inputDialog(nullptr, PointDataConversionPlugin::CONVERSIONS[PointDataConversionPlugin::Conversion::ArcSinh],
-            &_sameChannelSettingAction, &_singleDecimalSettingAction, &_channelWiseDecimalAction);
+            &_sameChannelSettingAction, &_arcSinFactorAction, &_arcSinFactorsAction);
         inputDialog.setModal(true);
         if (inputDialog.exec() == QDialog::Accepted)
             createPluginAndTransform(type, inputDataset);
@@ -335,7 +383,7 @@ void PointDataConversionPluginFactory::openConfigDialog(const PointDataConversio
     case PointDataConversionPlugin::Conversion::ClampMax:
     {
         ConversionDialog inputDialog(nullptr, PointDataConversionPlugin::CONVERSIONS[PointDataConversionPlugin::Conversion::ClampMax],
-            &_sameChannelSettingAction, &_singleDecimalSettingAction, &_channelWiseDecimalAction);
+            &_sameChannelSettingAction, &_percentileAction, &_percentilesAction);
         inputDialog.setModal(true);
         if (inputDialog.exec() == QDialog::Accepted)
             createPluginAndTransform(type, inputDataset);
@@ -346,7 +394,7 @@ void PointDataConversionPluginFactory::openConfigDialog(const PointDataConversio
 
 }
 
-void PointDataConversionPluginFactory::setConfigDialogDefaultSettings(const PointDataConversionPlugin::Conversion& type)
+void PointDataConversionPluginFactory::setConfigDialogDefaultSettings(const PointDataConversionPlugin::Conversion& type, const QStringList& dimensionNames)
 {
     switch (type)
     {
@@ -357,18 +405,16 @@ void PointDataConversionPluginFactory::setConfigDialogDefaultSettings(const Poin
 
     case PointDataConversionPlugin::Conversion::ArcSinh:
     {
-        _singleDecimalSettingAction.setText("Cofactor");
-        _singleDecimalSettingAction.setValue(5.f);
-        _channelWiseDecimalAction.setText("Cofactors");
-        _channelWiseDecimalAction.setValueForAllEntries(99.f);
+        _arcSinFactorAction.setValue(5.f);
+        _arcSinFactorsAction.setEntries(dimensionNames);
+        _arcSinFactorsAction.setValueForAllEntries(5.f);
         break;
     }
     case PointDataConversionPlugin::Conversion::ClampMax:
     {
-        _singleDecimalSettingAction.setText("Percentile");
-        _singleDecimalSettingAction.setValue(99.f);
-        _channelWiseDecimalAction.setText("Percentiles");
-        _channelWiseDecimalAction.setValueForAllEntries(99.f);
+        _percentileAction.setValue(99.f);
+        _percentilesAction.setEntries(dimensionNames);
+        _percentilesAction.setValueForAllEntries(99.f);
         break;
     }
 
@@ -381,7 +427,7 @@ void PointDataConversionPluginFactory::createPluginAndTransform(const PointDataC
 
     pluginInstance->setInputDataset(inputDataset);
     pluginInstance->setConversion(type);
-    pluginInstance->setConversionSetting(getConversionSetting());
+    pluginInstance->setConversionSetting(getConversionSetting(type));
     pluginInstance->transform();
 
 }

--- a/src/PointDataConversionPlugin.h
+++ b/src/PointDataConversionPlugin.h
@@ -125,13 +125,16 @@ public:
     void createPluginAndTransform(const PointDataConversionPlugin::Conversion& type, const mv::Dataset<mv::DatasetImpl>& inputDataset) const;
 
 private:
-    [[nodiscard]] std::vector<float> getConversionSetting() const;
+    [[nodiscard]] std::vector<float> getConversionSetting(const PointDataConversionPlugin::Conversion& conversion) const;
 
-    void setConfigDialogDefaultSettings(const PointDataConversionPlugin::Conversion& type);
+    void setConfigDialogDefaultSettings(const PointDataConversionPlugin::Conversion& type, const QStringList& dimensionNames);
 
 private:
     mv::gui::ToggleAction  _sameChannelSettingAction;
 
-    mv::gui::DecimalAction _singleDecimalSettingAction;
-    mv::gui::SlidersAction _channelWiseDecimalAction;
+    mv::gui::DecimalAction _arcSinFactorAction;
+    mv::gui::SlidersAction _arcSinFactorsAction;
+
+    mv::gui::DecimalAction _percentileAction;
+    mv::gui::SlidersAction _percentilesAction;
 };

--- a/src/SlidersAction.cpp
+++ b/src/SlidersAction.cpp
@@ -144,7 +144,7 @@ QWidget* SlidersAction::getWidget(QWidget* parent, const std::int32_t& widgetFla
 
         const EntryData& d = _entryData.at(opt);
 
-        DecimalAction* slider = new DecimalAction(row, opt, d.min, d.max, d.value, EntryData::DEFAULT_DECIMALS);
+        DecimalAction* slider = new DecimalAction(row, opt, d.min, d.max, d.value, DEFAULT_DECIMALS);
         rowLayout->addWidget(slider->createLabelWidget(row));
         rowLayout->addWidget(slider->createWidget(row));
 

--- a/src/SlidersAction.h
+++ b/src/SlidersAction.h
@@ -26,15 +26,12 @@ namespace mv::gui {
 
     public:
         struct EntryData {
-            static constexpr float DEFAULT_MIN = 1.0f;
-            static constexpr float DEFAULT_MAX = 100.0f;
-            static constexpr float DEFAULT_VALUE = 5.0f;
-            static constexpr std::int32_t DEFAULT_DECIMALS = 2;
-
-            float min = DEFAULT_MIN;
-            float max = DEFAULT_MAX;
-            float value = DEFAULT_VALUE;
+            float min = 0.f;
+            float max = 100.f;
+            float value = 1.f;
         };
+
+        static constexpr std::int32_t DEFAULT_DECIMALS = 2;
 
     public:
         explicit SlidersAction(QObject* parent, const QString& title);


### PR DESCRIPTION
After https://github.com/ManiVaultStudio/PointDataConversionPlugin/pull/18 and https://github.com/ManiVaultStudio/PointDataConversionPlugin/pull/19 the shared single channel settings action was adjusted every time a new conversion was added to the plugin trigger action in `PointDataConversionPluginFactory::getPluginTriggerActions(const mv::DataTypes& dataTypes)`.
This lead to only the last conversion setting being visible (i.e. it showed the "Percentile" setting name and default value for `ArcSinh` instead of "Cofactor").
I think the cleanest solution is to use one action per setting, as added in this PR. I've also added default values marcos for the settings.